### PR TITLE
Issue #3 - detect and delete 0 byte files

### DIFF
--- a/gbfproxy/handlers.py
+++ b/gbfproxy/handlers.py
@@ -36,6 +36,10 @@ def write_file(path, data, url, url_list_path):
 
     os.rename(temp_path, path)
 
+    if os.stat(path).st_size == 0:
+        logging.error('Bad file size: {0}'.format(path))
+        os.remove(path)
+
     logging.debug('Updating cache list: {0}'.format(url_list_path))
     F_LIST_LOCK.acquire()
     with open(url_list_path, 'ab') as csvf:


### PR DESCRIPTION
Fixes Issue #3 by deleting 0 byte cache files.

A quick hack. A better fix would be to just check if the data stream is 0 bytes and never attempt a write, but this method is good enough. Performance-wise, the effect is negligible since writing cache files to disk happens in a thread.