### PR TITLE
Update matcher regex to ignore captcha

### DIFF
--- a/gbf-proxy.ini
+++ b/gbf-proxy.ini
@@ -3,4 +3,4 @@ host = localhost
 port = 8080
 protocol = HTTP/1.1
 cache = ./cache
-matcher = .+\.granbluefantasy\.jp/.*
+matcher = .+\.granbluefantasy\.jp/(?!c/i\?t=)(.*)

--- a/gbfproxy/handlers.py
+++ b/gbfproxy/handlers.py
@@ -34,6 +34,10 @@ def write_file(path, data, url, url_list_path):
     with open(temp_path, 'wb') as f:
         f.write(data)
 
+    if os.path.getsize(temp_path) == 0:
+        logging.debug('Got zero byte cache file: {0}'.format(url))
+        return
+
     os.rename(temp_path, path)
 
     logging.debug('Updating cache list: {0}'.format(url_list_path))

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,2 @@
+source gbf-env/Scripts/activate
+python gbf-proxy.py


### PR DESCRIPTION
Quick fix to ignore the captcha image url.

No idea if it actually works in practice. The url we are looking to blacklist is:

```
http://game.granbluefantasy.jp/c/i?t=<timestamp>
```

This pull request also adds a small helper script for running the proxy, `run.sh`.