### PR TITLE
Provide a PAC file which will ignore authentication-related requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,13 +24,15 @@ You can use PAC files so that you don't need to proxy ALL your browser traffic t
 
 ```
 function FindProxyForURL(url, host) {
-	if (shExpMatch(url, "*.granbluefantasy.jp/*")) {
+	if (shExpMatch(url, "*.granbluefantasy.jp/*")
+		&& !shExpMatch(url, "*game.granbluefantasy.jp/(authentication|ob/r)*")) {
 		return "PROXY localhost:8080";
 	}
 
 	return "DIRECT";
 }
 ```
+This PAC file is also included in this repository as `gbf-proxy.pac`.
 
 ## Chrome on Windows with PAC files
 

--- a/gbf-proxy.pac
+++ b/gbf-proxy.pac
@@ -1,0 +1,8 @@
+function FindProxyForURL(url, host) {
+	if (shExpMatch(url, "*.granbluefantasy.jp/*")
+		&& !shExpMatch(url, "*game.granbluefantasy.jp/(authentication|ob/r)*")) {
+		return "PROXY localhost:8080";
+	}
+	
+	return "DIRECT";
+}


### PR DESCRIPTION
This is the simplest way to ignore authentication-related requests.

I thought about making the do_POST handling better in the Python, but it seems painful & annoying to maintain that.

For now, let's just ignore the URLs that the game POSTs when authenticating, and hopefully this will resolve login issues. Unfortunately, I cannot reproduce login issues so it is unclear whether this will actually fix it.